### PR TITLE
specify config file delimiter so it doesn't barf on windows paths

### DIFF
--- a/gitup/config.py
+++ b/gitup/config.py
@@ -39,7 +39,7 @@ def _migrate_old_config_path():
 def _load_config_file(config_path=None):
     """Read the config file and return a SafeConfigParser() object."""
     _migrate_old_config_path()
-    config = configparser.SafeConfigParser()
+    config = configparser.SafeConfigParser(delimiters='=')
     # Don't lowercase option names, because we are storing paths there:
     config.optionxform = lambda opt: opt
     config.read(config_path or get_default_config_path())


### PR DESCRIPTION
To avoid these types of errors on windows:
`configparser.DuplicateOptionError: While reading from 'C:\\Users\\m-s-\\.config\\gitup\\config.ini' [line  3]: option 'D' in section 'bookmarks' already exists`

for full paths like *D:\git\gitup*