### PR TITLE
fix duplicate detection in case agnostic systems

### DIFF
--- a/gitup/config.py
+++ b/gitup/config.py
@@ -59,7 +59,7 @@ def add_bookmarks(paths, config_path=None):
     config = _load_config_file(config_path)
     added, exists = [], []
     for path in paths:
-        path = os.path.abspath(path)
+        path = os.path.normcase(os.path.abspath(path))
         if path in config:
             exists.append(path)
         else:
@@ -83,7 +83,7 @@ def delete_bookmarks(paths, config_path=None):
     deleted, notmarked = [], []
     if config:
         for path in paths:
-            path = os.path.abspath(path)
+            path = os.path.normcase(os.path.abspath(path))
             if path in config:
                 config.remove(path)
                 deleted.append(path)


### PR DESCRIPTION
For your consideration, a fix allowing better duplicate detection in _case-agnostic systems_.  Needs to be tested on osx/linux (but they just could not have gotten this wront).  

[os.path.normcase](https://docs.python.org/2/library/os.path.html#os.path.normcase)
Normalize the case of a pathname. On Unix and Mac OS X, this returns the path unchanged; on case-insensitive filesystems, it converts the path to lowercase. On Windows, it also converts forward slashes to backward slashes.