### PR TITLE
Support simple comments in the bookmarks file

### DIFF
--- a/gitup/config.py
+++ b/gitup/config.py
@@ -37,26 +37,7 @@ def _load_config_file(config_path=None):
     except IOError:
         return []
     paths = [path.decode("utf8").strip() for path in paths]
-    paths = _strip_comment_lines(paths)
     return [path for path in paths if path]
-
-def _strip_comment_lines(paths):
-    """Remove any lines starting with #."""
-    i = 0
-    while i < len(paths):
-        path = paths[i]
-        removed_comment = False
-        for j in range(0, len(path)):
-            path_char = path[j]
-            if path_char == " ":
-                continue
-            if path_char == "#":
-                removed_comment = True
-                paths.pop(i)
-                break
-        if removed_comment is False:
-            i = i + 1
-    return paths
 
 def _save_config_file(bookmarks, config_path=None):
     """Save the bookmarks list to the given config file."""

--- a/gitup/config.py
+++ b/gitup/config.py
@@ -37,7 +37,26 @@ def _load_config_file(config_path=None):
     except IOError:
         return []
     paths = [path.decode("utf8").strip() for path in paths]
+    paths = _strip_comment_lines(paths)
     return [path for path in paths if path]
+
+def _strip_comment_lines(paths):
+    """Remove any lines starting with #."""
+    i = 0
+    while i < len(paths):
+        path = paths[i]
+        removed_comment = False
+        for j in range(0, len(path)):
+            path_char = path[j]
+            if path_char == " ":
+                continue
+            if path_char == "#":
+                removed_comment = True
+                paths.pop(i)
+                break
+        if removed_comment is False:
+            i = i + 1
+    return paths
 
 def _save_config_file(bookmarks, config_path=None):
     """Save the bookmarks list to the given config file."""


### PR DESCRIPTION
For your consideration.

I have a lot of repos listed in my bookmarks file; I thought I'd like to have comments in there as section headers. As it stands, the code rejects these as bad repos, so I've updated the code to check a given line is a comment line (starts with a #) and, if so, print the comment text during updates.

So if your bookmarks file contains:

```
# ****** MY IMP LIBRARIES ******
/Users/smitty/Documents/GitHub/DarkSky
```

you'll see when you run the code:

```
****** MY IMP LIBRARIES ******
/Users/smitty/Documents/GitHub/DarkSky (1 repo):
    DarkSky:
        Fetching origin: up to date.
        Updating develop: up to date.
        Updating master: up to date.
```

Cheers,

Tony