### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+dist: bionic
+
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+
+
+install:
+  - pipenv install
+
+script:
+  - pytest


### PR DESCRIPTION
Travis CI support, using Python 3.6, 3.7 and 3.8.